### PR TITLE
fix(build): ensure manifest-required assets are copied in production build (closes #25)

### DIFF
--- a/Frontend/webpack.prod.js
+++ b/Frontend/webpack.prod.js
@@ -6,7 +6,18 @@ module.exports = (env, argv) => {
 
   baseConfig.plugins.push(
     new CopyPlugin({
-      patterns: [{ from: "public" }],
+      patterns: [
+        { from: "public" },
+        { 
+          from: "src/content/css", 
+          to: "content/css",
+          globOptions: {
+            ignore: ["**/*.module.css"]
+          }
+        },
+        { from: "src/app/app.css", to: "app.css" },
+        { from: "src/shared/constants/LeetCode_Tags_Combined.json", to: "LeetCode_Tags_Combined.json" }
+      ],
     })
   );
 


### PR DESCRIPTION

### ✅ Pull Request Template

#### 🚀 Summary

Fixes a critical issue where the Chrome extension failed to load due to missing assets referenced in `manifest.json`. The production Webpack config did not emit necessary CSS and JSON files, leading to a “Manifest file is missing or unreadable” error.

#### 🔍 Related Issues

Closes #25

#### 🧪 What’s Been Done

* [x] Updated `webpack.prod.js`:

  * Added copy pattern for `src/content/css/ → dist/content/css/`
  * Added `src/app/app.css → dist/`
  * Added `src/shared/constants/LeetCode_Tags_Combined.json → dist/`
* [x] Rebuilt the app and verified all required assets are now present in `dist/`
* [x] Confirmed manifest loads successfully and extension installs without errors

#### 🧪 How to Test

1. Run `npm run build`
2. Open `dist/` and verify the following:

   * All content CSS files exist in `dist/content/css/`
   * `app.css` exists in `dist/`
   * `LeetCode_Tags_Combined.json` exists in `dist/`
3. Load the unpacked extension in Chrome and confirm there is **no manifest error**

#### 📸 Screenshots or Logs

N/A — Build output verified via manual inspection and Chrome extension load

#### 🛠 Checklist

* [x] Follows single-responsibility principle
* [x] Build works without regressions
* [x] Required files now copied consistently
* [x] No unused or leftover copy patterns added

#### 📎 Notes

This was a silent failure caused by manifest.json referencing files that were never copied to `dist/`. We now explicitly include those files in the Webpack production config to ensure reliable builds.


