### PR TITLE
fix(data): attempted problems appearing in new problem pool (#160)

### DIFF
--- a/chrome-extension-app/CHANGELOG.md
+++ b/chrome-extension-app/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - 2025-10-30
 
 ### Fixed
+**Attempted Problems in New Problem Pool** ([Issue #160](https://github.com/smithrashell/CodeMaster/issues/160)):
+- Fixed attempted problems incorrectly appearing in new problem pool during session generation
+- Root cause: `loadProblemSelectionContext()` in `problems.js:580` not filtering out attempted problems from `standard_problems` store
+- Impact: Prevents duplicates where same problem appears as both review and "new" problem
+- Solution: Added filtering logic to exclude attempted problems (from `problems` store) before returning available problem pool
+- Ensures proper separation between review pool (attempted) and new pool (unattempted)
+- Verified working by user: Sessions generate without issues after fix
+- File modified: `chrome-extension-app/src/shared/db/problems.js`
+
 
 **Box Level Distribution Statistics** ([Issue #159](https://github.com/smithrashell/CodeMaster/issues/159)):
 - Fixed Statistics page displaying incorrect box level distribution (all problems shown in Box 1 at 100%)

--- a/chrome-extension-app/src/shared/db/problems.js
+++ b/chrome-extension-app/src/shared/db/problems.js
@@ -583,10 +583,24 @@ async function loadProblemSelectionContext(currentDifficultyCap) {
   const allProblems = await getAllStandardProblems();
   const ladders = await getPatternLadders();
 
-  let availableProblems = allProblems;
+  // Get attempted problems from problems store
+  // All problems in this store have been attempted by the user
+  const attemptedProblems = await fetchAllProblems();
+  const attemptedProblemIds = new Set(
+    attemptedProblems.map(p => Number(p.leetcode_id))
+  );
+  logger.info(`🎯 Excluding ${attemptedProblemIds.size} attempted problems from selection`);
+
+  // Filter out attempted problems
+  let availableProblems = allProblems.filter(problem => {
+    const problemId = Number(problem.id || problem.leetcode_id);
+    return !attemptedProblemIds.has(problemId);
+  });
+  logger.info(`🎯 Available problems after filtering attempts: ${availableProblems.length}/${allProblems.length}`);
+
   if (currentDifficultyCap) {
-    availableProblems = filterProblemsByDifficultyCap(allProblems, currentDifficultyCap);
-    logger.info(`🎯 Difficulty cap applied: ${currentDifficultyCap} (${availableProblems.length}/${allProblems.length} problems)`);
+    availableProblems = filterProblemsByDifficultyCap(availableProblems, currentDifficultyCap);
+    logger.info(`🎯 Difficulty cap applied: ${currentDifficultyCap} (${availableProblems.length} problems)`);
   }
 
   const focusDecision = await FocusCoordinationService.getFocusDecision("session_state");


### PR DESCRIPTION
## Summary

Fixes attempted problems incorrectly appearing in the new problem pool during session generation ([Issue #160](https://github.com/smithrashell/CodeMaster/issues/160))

**Root Cause**: `loadProblemSelectionContext()` in `problems.js:580` was not filtering out attempted problems from the `standard_problems` store, causing duplicates where the same problem could appear as both a review problem and a "new" problem.

**Solution**: Added filtering logic to exclude attempted problems (from the `problems` store) before returning the available problem pool, ensuring proper separation between the review pool (attempted) and new pool (unattempted).

## Changes

- Modified `loadProblemSelectionContext()` in `chrome-extension-app/src/shared/db/problems.js`
- Added filtering to exclude attempted problem IDs from the standard problems pool
- Updated CHANGELOG with detailed documentation

## Test Plan

- [x] Verified filtering logic correctly excludes attempted problems
- [x] Confirmed user reported sessions generate without issues after fix
- [x] Ensured no duplicates between review and new problem pools
- [ ] Test session generation with various problem sets
- [ ] Verify statistics remain accurate after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)