### PR TITLE
fix(services): add missing getAllProblems method to ProblemService (Issue #216)

### DIFF
--- a/chrome-extension-app/src/shared/services/__tests__/problemService.test.js
+++ b/chrome-extension-app/src/shared/services/__tests__/problemService.test.js
@@ -211,6 +211,33 @@ const runGetProblemByDescriptionTests = () => {
   });
 };
 
+const runGetAllProblemsTests = () => {
+  describe("getAllProblems", () => {
+    beforeEach(() => {
+      problemsDb.fetchAllProblems.mockClear();
+    });
+
+    it("should return all problems from the database", async () => {
+      const mockProblems = createMockProblemsArray();
+      setupMockFetchAllProblems(mockProblems);
+
+      const result = await ProblemService.getAllProblems();
+
+      expect(problemsDb.fetchAllProblems).toHaveBeenCalled();
+      expect(result).toEqual(mockProblems);
+    });
+
+    it("should return empty array when no problems exist", async () => {
+      setupMockFetchAllProblems([]);
+
+      const result = await ProblemService.getAllProblems();
+
+      expect(problemsDb.fetchAllProblems).toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+};
+
 const runAddOrUpdateProblemTests = () => {
   describe("addOrUpdateProblem", () => {
     beforeEach(() => {
@@ -685,6 +712,7 @@ describe("ProblemService", () => {
   });
 
   runGetProblemByDescriptionTests();
+  runGetAllProblemsTests();
   runAddOrUpdateProblemTests();
   runCreateSessionTests();
   runBuildUserPerformanceContextTests();

--- a/chrome-extension-app/src/shared/services/problem/problemService.js
+++ b/chrome-extension-app/src/shared/services/problem/problemService.js
@@ -97,6 +97,10 @@ export const ProblemService = {
     return countProblemsByBoxLevel();
   },
 
+  getAllProblems() {
+    return fetchAllProblems();
+  },
+
   async addOrUpdateProblem(contentScriptData) {
     logger.info("addOrUpdateProblem called", { contentScriptData });
 


### PR DESCRIPTION
## Summary
- Added missing `getAllProblems()` method to `ProblemService`
- Added unit tests for the new method

## Problem
`ProblemService.getAllProblems()` was called in `problemHandlers.js:131` but the method didn't exist. Tests passed because they mocked the method, hiding the runtime bug.

## Fix
Added the method that delegates to `fetchAllProblems()` from the database layer.

## Test Plan
- [x] Run `npm run lint` - no errors
- [x] Run `npm test` - 535 tests passing

Closes #216