### PR TITLE
refactor(leitner): standardize function naming per Clean Code guidelines (Issue #215)

### DIFF
--- a/chrome-extension-app/src/shared/utils/leitner/leitnerHelpers.js
+++ b/chrome-extension-app/src/shared/utils/leitner/leitnerHelpers.js
@@ -11,7 +11,7 @@ const TIME_LIMITS_BY_DIFFICULTY = { 1: 15, 2: 25, 3: 40 };
 /**
  * Calculate time performance score based on attempt data
  */
-export function computeTimePerformanceScore(attemptData, useTimeLimits = true) {
+export function calculateTimePerformanceScore(attemptData, useTimeLimits = true) {
   if (!useTimeLimits || !attemptData) {
     return { timePerformanceScore: 1.0, exceededTimeLimit: false };
   }

--- a/chrome-extension-app/src/shared/utils/leitner/leitnerSystem.js
+++ b/chrome-extension-app/src/shared/utils/leitner/leitnerSystem.js
@@ -6,7 +6,7 @@ import {
 // eslint-disable-next-line no-restricted-imports
 import { dbHelper } from "../../db/index.js";
 import {
-  computeTimePerformanceScore,
+  calculateTimePerformanceScore,
   applyBoxLevelAdjustments,
   applyStabilityAdjustment,
   calculateNextReviewDate,
@@ -155,7 +155,7 @@ function calculateLeitnerBox(problem, attemptData, useTimeLimits = true) {
   console.info("problem", problem);
 
   // Step 1: Calculate time performance score
-  const { timePerformanceScore, exceededTimeLimit } = computeTimePerformanceScore(attemptData, useTimeLimits);
+  const { timePerformanceScore, exceededTimeLimit } = calculateTimePerformanceScore(attemptData, useTimeLimits);
 
   // Step 2: Apply box level adjustments based on success/failure
   problem = applyBoxLevelAdjustments(problem, attemptData, timePerformanceScore);


### PR DESCRIPTION
## Summary

Renames `computeTimePerformanceScore` to `calculateTimePerformanceScore` to follow Clean Code Chapter 2 naming conventions ("Pick One Word per Concept").

### Changes
- Renamed function in `leitnerHelpers.js`
- Updated import in `leitnerSystem.js`
- Updated function call in `leitnerSystem.js`

### Rationale
The codebase uses `calculate` (23 occurrences) as the standard verb for computing values, while `compute` was only used once. This change aligns with the established convention.

## Test Plan
- [x] All 723 tests pass
- [x] Lint passes with no errors

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)